### PR TITLE
Adds scripts/release.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# release/ director built by scripts/release.sh
+release

--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ To start the software suite, do the following on the master Raspberry Pi device,
    instructions [here](https://github.com/pakohan/craftdoor.git).
 1. Download `golang` from https://golang.org. Follow installation instructions
    [here](https://golang.org/doc/install#install). Verify that go is installed
-   by running `go version` in a terminal.
+   by running `go version` in a terminal. Expect to see >= 1.14.
+1. Install GCC cross-compiler,
+  ```
+  $ sudo apt install gcc-arm-linux-gnueabi libc6-armel-cross \
+    libc6-dev-armel-cross binutils-arm-linux-gnueabi
+  ```
 1. Run `cmd/master/main.go`. This will launch a webserver listening on port 8080.
   ```
   $ git clone https://github.com/pakohan/craftdoor.git

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Build and release
+#
+
+set -e
+
+SRC="cmd/master/"
+DST="release/"
+
+# cd into project root.
+PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/../
+cd "${PROJECT_ROOT}"
+
+# Clean the release/ directory.
+rm -rf "${DST}"
+mkdir -p "${DST}"
+
+# Build for ARM.
+env GOOS=linux \
+    GOARCH=arm \
+    GOARM=5 \
+    CGO_ENABLED=1 \
+    CC=arm-linux-gnueabi-gcc \
+    go build -o "${DST}/main" "${SRC}/main.go"
+
+# Copy auxiliary files.
+cp ${SRC}/develop.json ${DST}/
+cp ${SRC}/schema.sql ${DST}/
+
+echo "Finished building '${SRC}'. Copy '${DST}' to your RPi and run it. For example,"
+echo "$ rsync -r release/ pi@raspberrypi:/home/pi/craftdoor"
+echo "$ ssh pi@raspberrypi 'cd /home/pi/craftdoor && ./main develop.json'"


### PR DESCRIPTION
Adds a script for building and a release-ready directory. This script creates a `release/` directory which can be copied directly to the Raspberry Pi and run without compiling on-device.

Includes `schema.sql` and `develop.json`. 